### PR TITLE
c-ffi,go-lockbook: better support for uuids

### DIFF
--- a/c_interface_v2/src/files.rs
+++ b/c_interface_v2/src/files.rs
@@ -6,10 +6,17 @@ use lockbook_core::{
 
 use crate::*;
 
+pub const UUID_LEN: usize = 16;
+
+#[repr(C)]
+pub struct LbFileId {
+    data: [u8; UUID_LEN],
+}
+
 #[repr(C)]
 pub struct LbFile {
-    id: *mut c_char,
-    parent: *mut c_char,
+    id: [u8; 16],
+    parent: [u8; 16],
     name: *mut c_char,
     typ: LbFileType,
     lastmod_by: *mut c_char,
@@ -27,8 +34,8 @@ pub fn lb_file_new(f: File) -> LbFile {
         typ.link_target = target.into_bytes();
     }
     LbFile {
-        id: cstr(f.id.to_string()),
-        parent: cstr(f.parent.to_string()),
+        id: f.id.into_bytes(),
+        parent: f.parent.into_bytes(),
         name: cstr(f.name),
         typ,
         lastmod_by: cstr(f.last_modified_by),
@@ -38,12 +45,6 @@ pub fn lb_file_new(f: File) -> LbFile {
 }
 
 pub unsafe fn lb_file_free(f: LbFile) {
-    if !f.id.is_null() {
-        let _ = CString::from_raw(f.id);
-    }
-    if !f.parent.is_null() {
-        let _ = CString::from_raw(f.parent);
-    }
     if !f.name.is_null() {
         let _ = CString::from_raw(f.name);
     }
@@ -140,8 +141,8 @@ pub struct LbFileResult {
 fn lb_file_result_new() -> LbFileResult {
     LbFileResult {
         ok: LbFile {
-            id: null_mut(),
-            parent: null_mut(),
+            id: [0; 16],
+            parent: [0; 16],
             name: null_mut(),
             typ: lb_file_type_doc(),
             lastmod_by: null_mut(),
@@ -217,11 +218,11 @@ unsafe fn lb_file_list_init(fl: &mut LbFileList, from: Vec<File>) {
 pub unsafe extern "C" fn lb_create_file(
     core: *mut c_void,
     name: *const c_char,
-    parent: *const c_char,
+    parent: LbFileId,
     ft: LbFileType,
 ) -> LbFileResult {
     let mut r = lb_file_result_new();
-    let parent = uuid_or_return!(parent, r);
+    let parent = Uuid::from_bytes(parent.data);
     let ftype = match ft.tag {
         LbFileTypeTag::Document => FileType::Document,
         LbFileTypeTag::Folder => FileType::Folder,
@@ -272,9 +273,9 @@ pub unsafe extern "C" fn lb_create_file_at_path(
 ///
 /// The returned value must be passed to `lb_file_result_free` to avoid a memory leak.
 #[no_mangle]
-pub unsafe extern "C" fn lb_get_file_by_id(core: *mut c_void, id: *const c_char) -> LbFileResult {
+pub unsafe extern "C" fn lb_get_file_by_id(core: *mut c_void, id: LbFileId) -> LbFileResult {
     let mut r = lb_file_result_new();
-    let id = uuid_or_return!(id, r);
+    let id = Uuid::from_bytes(id.data);
     match core!(core).get_file_by_id(id) {
         Ok(f) => r.ok = lb_file_new(f),
         Err(err) => {
@@ -318,9 +319,9 @@ pub unsafe extern "C" fn lb_get_file_by_path(
 ///
 /// The returned value must be passed to `lb_string_result_free` to avoid a memory leak.
 #[no_mangle]
-pub unsafe extern "C" fn lb_get_path_by_id(core: *mut c_void, id: *const c_char) -> LbStringResult {
+pub unsafe extern "C" fn lb_get_path_by_id(core: *mut c_void, id: LbFileId) -> LbStringResult {
     let mut r = lb_string_result_new();
-    let id = uuid_or_return!(id, r);
+    let id = Uuid::from_bytes(id.data);
     match core!(core).get_path_by_id(id) {
         Ok(path) => r.ok = cstr(path),
         Err(err) => {
@@ -351,9 +352,9 @@ pub unsafe extern "C" fn lb_get_root(core: *mut c_void) -> LbFileResult {
 ///
 /// The returned value must be passed to `lb_file_list_result_free` to avoid a memory leak.
 #[no_mangle]
-pub unsafe extern "C" fn lb_get_children(core: *mut c_void, id: *const c_char) -> LbFileListResult {
+pub unsafe extern "C" fn lb_get_children(core: *mut c_void, id: LbFileId) -> LbFileListResult {
     let mut r = lb_file_list_result_new();
-    let id = uuid_or_return!(id, r);
+    let id = Uuid::from_bytes(id.data);
     match core!(core).get_children(id) {
         Ok(files) => lb_file_list_init(&mut r.ok, files),
         Err(err) => {
@@ -370,10 +371,10 @@ pub unsafe extern "C" fn lb_get_children(core: *mut c_void, id: *const c_char) -
 #[no_mangle]
 pub unsafe extern "C" fn lb_get_and_get_children_recursively(
     core: *mut c_void,
-    id: *const c_char,
+    id: LbFileId,
 ) -> LbFileListResult {
     let mut r = lb_file_list_result_new();
-    let id = uuid_or_return!(id, r);
+    let id = Uuid::from_bytes(id.data);
     match core!(core).get_and_get_children_recursively(id) {
         Ok(files) => lb_file_list_init(&mut r.ok, files),
         Err(err) => {
@@ -411,9 +412,9 @@ pub unsafe extern "C" fn lb_list_metadatas(core: *mut c_void) -> LbFileListResul
 ///
 /// The returned value must be passed to `lb_bytes_result_free` to avoid a memory leak.
 #[no_mangle]
-pub unsafe extern "C" fn lb_read_document(core: *mut c_void, id: *const c_char) -> LbBytesResult {
+pub unsafe extern "C" fn lb_read_document(core: *mut c_void, id: LbFileId) -> LbBytesResult {
     let mut r = lb_bytes_result_new();
-    let id = uuid_or_return!(id, r);
+    let id = Uuid::from_bytes(id.data);
     match core!(core).read_document(id) {
         Ok(mut data) => {
             data.shrink_to_fit();
@@ -442,12 +443,12 @@ pub unsafe extern "C" fn lb_read_document(core: *mut c_void, id: *const c_char) 
 #[no_mangle]
 pub unsafe extern "C" fn lb_write_document(
     core: *mut c_void,
-    id: *const c_char,
+    id: LbFileId,
     data: *const u8,
     len: i32,
 ) -> LbError {
     let mut e = lb_error_none();
-    let id = uuid_or_return!(id);
+    let id = Uuid::from_bytes(id.data);
     let data = std::slice::from_raw_parts(data, len as usize);
     if let Err(err) = core!(core).write_document(id, data) {
         use WriteToDocumentError::*;
@@ -489,13 +490,13 @@ pub type LbImexCallback = unsafe extern "C" fn(LbImexFileInfo, *mut c_void);
 #[no_mangle]
 pub unsafe extern "C" fn lb_export_file(
     core: *mut c_void,
-    id: *const c_char,
+    id: LbFileId,
     dest: *const c_char,
     progress: LbImexCallback,
     user_data: *mut c_void,
 ) -> LbError {
     let mut e = lb_error_none();
-    let id = uuid_or_return!(id);
+    let id = Uuid::from_bytes(id.data);
     if let Err(err) = core!(core).export_file(
         id,
         rstr(dest).into(),
@@ -528,11 +529,11 @@ pub unsafe extern "C" fn lb_export_file(
 #[no_mangle]
 pub unsafe extern "C" fn lb_export_drawing(
     core: *mut c_void,
-    id: *const c_char,
+    id: LbFileId,
     fmt_code: u8,
 ) -> LbBytesResult {
     let mut r = lb_bytes_result_new();
-    let id = uuid_or_return!(id, r);
+    let id = Uuid::from_bytes(id.data);
     // These values are bound together in a unit test in this crate.
     let img_fmt = match fmt_code {
         0 => SupportedImageFormats::Png,
@@ -574,9 +575,9 @@ pub unsafe extern "C" fn lb_export_drawing(
 ///
 /// The returned value must be passed to `lb_error_free` to avoid a memory leak.
 #[no_mangle]
-pub unsafe extern "C" fn lb_delete_file(core: *mut c_void, id: *const c_char) -> LbError {
+pub unsafe extern "C" fn lb_delete_file(core: *mut c_void, id: LbFileId) -> LbError {
     let mut e = lb_error_none();
-    let id = uuid_or_return!(id);
+    let id = Uuid::from_bytes(id.data);
     if let Err(err) = core!(core).delete_file(id) {
         use FileDeleteError::*;
         e.msg = cstr(format!("{:?}", err));
@@ -598,12 +599,12 @@ pub unsafe extern "C" fn lb_delete_file(core: *mut c_void, id: *const c_char) ->
 #[no_mangle]
 pub unsafe extern "C" fn lb_move_file(
     core: *mut c_void,
-    id: *const c_char,
-    new_parent: *const c_char,
+    id: LbFileId,
+    new_parent: LbFileId,
 ) -> LbError {
     let mut e = lb_error_none();
-    let id = uuid_or_return!(id);
-    let new_parent = uuid_or_return!(new_parent);
+    let id = Uuid::from_bytes(id.data);
+    let new_parent = Uuid::from_bytes(new_parent.data);
     if let Err(err) = core!(core).move_file(id, new_parent) {
         use MoveFileError::*;
         e.msg = cstr(format!("{:?}", err));
@@ -630,11 +631,11 @@ pub unsafe extern "C" fn lb_move_file(
 #[no_mangle]
 pub unsafe extern "C" fn lb_rename_file(
     core: *mut c_void,
-    id: *const c_char,
+    id: LbFileId,
     new_name: *const c_char,
 ) -> LbError {
     let mut e = lb_error_none();
-    let id = uuid_or_return!(id);
+    let id = Uuid::from_bytes(id.data);
     if let Err(err) = core!(core).rename_file(id, rstr(new_name)) {
         use RenameFileError::*;
         e.msg = cstr(format!("{:?}", err));
@@ -659,12 +660,12 @@ pub unsafe extern "C" fn lb_rename_file(
 #[no_mangle]
 pub unsafe extern "C" fn lb_share_file(
     core: *mut c_void,
-    id: *const c_char,
+    id: LbFileId,
     uname: *const c_char,
     mode: LbShareMode,
 ) -> LbError {
     let mut e = lb_error_none();
-    let id = uuid_or_return!(id);
+    let id = Uuid::from_bytes(id.data);
     let mode = match mode {
         LbShareMode::Read => ShareMode::Read,
         LbShareMode::Write => ShareMode::Write,
@@ -696,9 +697,9 @@ pub unsafe extern "C" fn lb_get_pending_shares(core: *mut c_void) -> LbFileListR
 ///
 /// The returned value must be passed to `lb_error_free` to avoid a memory leak.
 #[no_mangle]
-pub unsafe extern "C" fn lb_delete_pending_share(core: *mut c_void, id: *const c_char) -> LbError {
+pub unsafe extern "C" fn lb_delete_pending_share(core: *mut c_void, id: LbFileId) -> LbError {
     let mut e = lb_error_none();
-    let id = uuid_or_return!(id);
+    let id = Uuid::from_bytes(id.data);
     if let Err(err) = core!(core).delete_pending_share(id) {
         e.msg = cstr(format!("{:?}", err));
         e.code = match err {

--- a/c_interface_v2/src/lib.rs
+++ b/c_interface_v2/src/lib.rs
@@ -20,40 +20,13 @@ unsafe fn rstr<'a>(s: *const c_char) -> &'a str {
     CStr::from_ptr(s).to_str().expect("*const char -> &str")
 }
 
-unsafe fn parse_c_uuid(c_id: *const c_char) -> Result<Uuid, LbError> {
-    let s = rstr(c_id);
-    s.parse().map_err(|_| LbError {
-        code: LbErrorCode::Unexpected,
-        msg: cstr(format!("unable to parse uuid '{}'", s)),
-    })
-}
-
 macro_rules! core {
     ($ptr:ident) => {
         &*($ptr as *mut Core)
     };
 }
 
-macro_rules! uuid_or_return {
-    ($id:expr) => {
-        match parse_c_uuid($id) {
-            Ok(id) => id,
-            Err(err) => return err,
-        }
-    };
-    ($id:expr, $result:ident) => {
-        match parse_c_uuid($id) {
-            Ok(id) => id,
-            Err(err) => {
-                $result.err = err;
-                return $result;
-            }
-        }
-    };
-}
-
 pub(crate) use core;
-pub(crate) use uuid_or_return;
 
 /// # Safety
 #[no_mangle]

--- a/go-lockbook/lockbook.go
+++ b/go-lockbook/lockbook.go
@@ -15,25 +15,25 @@ type Core interface {
 	ImportAccount(acctStr string) (Account, error)
 	ExportAccount() (string, error)
 
-	FileByID(id uuid.UUID) (File, error)
+	FileByID(id FileID) (File, error)
 	FileByPath(lbPath string) (File, error)
 	GetRoot() (File, error)
-	GetChildren(id uuid.UUID) ([]File, error)
-	GetAndGetChildrenRecursively(id uuid.UUID) ([]File, error)
+	GetChildren(id FileID) ([]File, error)
+	GetAndGetChildrenRecursively(id FileID) ([]File, error)
 	ListMetadatas() ([]File, error)
-	PathByID(id uuid.UUID) (string, error)
+	PathByID(id FileID) (string, error)
 
-	ReadDocument(id uuid.UUID) ([]byte, error)
-	WriteDocument(id uuid.UUID, data []byte) error
+	ReadDocument(id FileID) ([]byte, error)
+	WriteDocument(id FileID, data []byte) error
 
-	CreateFile(name string, parentID uuid.UUID, typ FileType) (File, error)
+	CreateFile(name string, parentID FileID, typ FileType) (File, error)
 	CreateFileAtPath(lbPath string) (File, error)
-	DeleteFile(id uuid.UUID) error
-	RenameFile(id uuid.UUID, newName string) error
-	MoveFile(srcID, destID uuid.UUID) error
+	DeleteFile(id FileID) error
+	RenameFile(id FileID, newName string) error
+	MoveFile(srcID, destID FileID) error
 
-	ExportFile(id uuid.UUID, dest string, fn func(ImportExportFileInfo)) error
-	ExportDrawing(id uuid.UUID, imgFmt ImageFormat) ([]byte, error)
+	ExportFile(id FileID, dest string, fn func(ImportExportFileInfo)) error
+	ExportDrawing(id FileID, imgFmt ImageFormat) ([]byte, error)
 
 	GetLastSyncedHumanString() (string, error)
 	GetUsage() (UsageMetrics, error)
@@ -41,9 +41,9 @@ type Core interface {
 	CalculateWork() (WorkCalculated, error)
 	SyncAll(fn func(SyncProgress)) error
 
-	ShareFile(id uuid.UUID, uname string, mode ShareMode) error
+	ShareFile(id FileID, uname string, mode ShareMode) error
 	GetPendingShares() ([]File, error)
-	DeletePendingShare(id uuid.UUID) error
+	DeletePendingShare(id FileID) error
 
 	GetSubscriptionInfo() (SubscriptionInfo, error)
 	UpgradeViaStripe(card *CreditCard) error
@@ -108,9 +108,11 @@ type Account struct {
 	APIURL   string
 }
 
+type FileID = uuid.UUID
+
 type File struct {
-	ID        uuid.UUID
-	Parent    uuid.UUID
+	ID        FileID
+	Parent    FileID
 	Name      string
 	Type      FileType
 	Lastmod   time.Time
@@ -132,7 +134,7 @@ type (
 
 	FileTypeDocument struct{}
 	FileTypeFolder   struct{}
-	FileTypeLink     struct{ Target uuid.UUID }
+	FileTypeLink     struct{ Target FileID }
 )
 
 func (_ FileTypeDocument) implsFileType() {}

--- a/go-lockbook/lockbook.go
+++ b/go-lockbook/lockbook.go
@@ -15,25 +15,25 @@ type Core interface {
 	ImportAccount(acctStr string) (Account, error)
 	ExportAccount() (string, error)
 
-	FileByID(id string) (File, error)
+	FileByID(id uuid.UUID) (File, error)
 	FileByPath(lbPath string) (File, error)
 	GetRoot() (File, error)
-	GetChildren(id string) ([]File, error)
-	GetAndGetChildrenRecursively(id string) ([]File, error)
+	GetChildren(id uuid.UUID) ([]File, error)
+	GetAndGetChildrenRecursively(id uuid.UUID) ([]File, error)
 	ListMetadatas() ([]File, error)
-	PathByID(id string) (string, error)
+	PathByID(id uuid.UUID) (string, error)
 
-	ReadDocument(id string) ([]byte, error)
-	WriteDocument(id string, data []byte) error
+	ReadDocument(id uuid.UUID) ([]byte, error)
+	WriteDocument(id uuid.UUID, data []byte) error
 
-	CreateFile(name, parentID string, typ FileType) (File, error)
+	CreateFile(name string, parentID uuid.UUID, typ FileType) (File, error)
 	CreateFileAtPath(lbPath string) (File, error)
-	DeleteFile(id string) error
-	RenameFile(id string, newName string) error
-	MoveFile(srcID, destID string) error
+	DeleteFile(id uuid.UUID) error
+	RenameFile(id uuid.UUID, newName string) error
+	MoveFile(srcID, destID uuid.UUID) error
 
-	ExportFile(id, dest string, fn func(ImportExportFileInfo)) error
-	ExportDrawing(id string, imgFmt ImageFormat) ([]byte, error)
+	ExportFile(id uuid.UUID, dest string, fn func(ImportExportFileInfo)) error
+	ExportDrawing(id uuid.UUID, imgFmt ImageFormat) ([]byte, error)
 
 	GetLastSyncedHumanString() (string, error)
 	GetUsage() (UsageMetrics, error)
@@ -41,9 +41,9 @@ type Core interface {
 	CalculateWork() (WorkCalculated, error)
 	SyncAll(fn func(SyncProgress)) error
 
-	ShareFile(id, uname string, mode ShareMode) error
+	ShareFile(id uuid.UUID, uname string, mode ShareMode) error
 	GetPendingShares() ([]File, error)
-	DeletePendingShare(id string) error
+	DeletePendingShare(id uuid.UUID) error
 
 	GetSubscriptionInfo() (SubscriptionInfo, error)
 	UpgradeViaStripe(card *CreditCard) error
@@ -109,8 +109,8 @@ type Account struct {
 }
 
 type File struct {
-	ID        string
-	Parent    string
+	ID        uuid.UUID
+	Parent    uuid.UUID
 	Name      string
 	Type      FileType
 	Lastmod   time.Time

--- a/go-lockbook/lockbook.go
+++ b/go-lockbook/lockbook.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/gofrs/uuid"
 )
 
 type Core interface {
@@ -130,7 +132,7 @@ type (
 
 	FileTypeDocument struct{}
 	FileTypeFolder   struct{}
-	FileTypeLink     struct{ Target string }
+	FileTypeLink     struct{ Target uuid.UUID }
 )
 
 func (_ FileTypeDocument) implsFileType() {}
@@ -144,7 +146,7 @@ func FileTypeString(t FileType) string {
 	case FileTypeFolder:
 		return "Folder"
 	case FileTypeLink:
-		return "Link('" + t.Target + "')"
+		return "Link('" + t.Target.String() + "')"
 	default:
 		return fmt.Sprintf("FileType(%v)", t)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	gioui.org v0.0.0-20221116222243-5c84cf7e9021
+	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/steverusso/gio-fonts v0.0.0-20221207034752-d3d43d7eae48
 	github.com/steverusso/mdedit v0.0.0-20221215033847-21feaf69cd7a
 	github.com/urfave/cli/v2 v2.23.7

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/gioui/uax v0.2.1-0.20220819135011-cda973fac06d h1:ro1W5kY1pVBLHy4GokZ
 github.com/gioui/uax v0.2.1-0.20220819135011-cda973fac06d/go.mod h1:b6uGh9ySJPVQG/RdiI88bE5sUGDk6vzzRujv1BAeuJc=
 github.com/go-text/typesetting v0.0.0-20220411150340-35994bc27a7b h1:WINlj3ANt+CVrO2B4NGDHRlPvEWZPxjhb7z+JKypwXI=
 github.com/go-text/typesetting v0.0.0-20220411150340-35994bc27a7b/go.mod h1:ZNYu5saGoMOqtkVH5T8onTwhzenDUVszI+5WFHJRaxQ=
+github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+CFIY7dBJI=
+github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/steverusso/gio-fonts v0.0.0-20221207034752-d3d43d7eae48 h1:ykYdzm6qenf6q9PDzy756ogG2QovKTwGJrskCfjr+XI=

--- a/lbcli/debug.go
+++ b/lbcli/debug.go
@@ -42,8 +42,8 @@ func printFile(f lb.File, myName string) {
 	}
 	data := [][2]string{
 		{"name", f.Name},
-		{"id", f.ID},
-		{"parent", f.Parent},
+		{"id", f.ID.String()},
+		{"parent", f.Parent.String()},
 		{"type", strings.ToLower(lb.FileTypeString(f.Type))},
 		{"lastmod", fmt.Sprintf("%v", f.Lastmod)},
 		{"lastmod_by", f.LastmodBy},

--- a/lbcli/files.go
+++ b/lbcli/files.go
@@ -88,7 +88,7 @@ func moveFile(core lb.Core, srcTarget, destTarget string) error {
 }
 
 func deleteFiles(core lb.Core, targets []string, isForce bool) error {
-	ids := make([]string, len(targets))
+	ids := make([]lb.FileID, len(targets))
 	for i, t := range targets {
 		id, err := idFromSomething(core, t)
 		if err != nil {
@@ -96,14 +96,14 @@ func deleteFiles(core lb.Core, targets []string, isForce bool) error {
 		}
 		ids[i] = id
 	}
-	for i, id := range targets {
+	for i, id := range ids {
 		f, err := core.FileByID(id)
 		if err != nil {
 			return fmt.Errorf("file by id %q: %w", id, err)
 		}
 		if !isForce {
 			phrase := fmt.Sprintf("delete %q", id)
-			if t := targets[i]; t != id {
+			if t := targets[i]; t != id.String() {
 				phrase += " (target: " + t + ")"
 			}
 			if f.IsDir() {

--- a/lbcli/ls.go
+++ b/lbcli/ls.go
@@ -31,7 +31,7 @@ type lsConfig struct {
 }
 
 type fileNode struct {
-	id         string
+	id         lb.FileID
 	dirName    string
 	name       string
 	isDir      bool
@@ -42,7 +42,7 @@ type fileNode struct {
 
 func (node *fileNode) text(cfg *lsConfig) (s string) {
 	if !cfg.short {
-		s += fmt.Sprintf("%-*s  ", cfg.idWidth, node.id[:cfg.idWidth])
+		s += fmt.Sprintf("%-*s  ", cfg.idWidth, node.id.String()[:cfg.idWidth])
 	}
 	nameOrPath := node.name
 	if cfg.paths {
@@ -71,7 +71,7 @@ func (node *fileNode) printOut(cfg *lsConfig) {
 	}
 }
 
-func getChildren(core lb.Core, files []lb.File, parent string, cfg *lsConfig) ([]fileNode, error) {
+func getChildren(core lb.Core, files []lb.File, parent lb.FileID, cfg *lsConfig) ([]fileNode, error) {
 	lockbook.SortFiles(files)
 	children := []fileNode{}
 	for i := range files {


### PR DESCRIPTION
Currently in the "C interface" as well call it, file IDs (which are [v4 UUIDs](https://docs.rs/uuid/latest/uuid/index.html)) are passed over FFI as C strings (both ways), and they're stored as strings in Go. There are two major changes in this PR:
1. UUIDs will be passed over FFI both ways as 16 byte array values.
2. UUIDs in Go will be a more powerful UUID type instead of a plain string.

### Memory Efficiency Throughout

Memory usage for a UUID as a string in Go is 52 bytes:
* the [string header](https://pkg.go.dev/reflect#StringHeader) is 16 (the pointer and length are each 8)
* the actual hex representation (aka. the length of the string's content) is 36

That's not to mention the overhead of heap allocating and freeing a C string to pass over FFI each way.

### Ergonomics, Particularly in Go

For developers consuming the C API as is, it'd be better to have one less heap allocated value to think about, especially when the value in question (a UUID) has a small and known size. But for Go developers, it'd be cool to use a UUID library such as [gofrs/uuid](https://pkg.go.dev/github.com/gofrs/uuid) instead of plain old strings.

---

### Improvements & Summary

UUID values are stack allocated and copied both ways over FFI. They're stored as a `uuid.UUID` in Go (which is essentially a `[16]byte`). No heap allocations either way, and the C values in Go aren't even managed by the GC.

**Side note:** C _only_ passes arrays by pointer, and `cbindgen` has [adjusted for this](https://github.com/rust-lang/rust/issues/58905) and will warn you if you try it. Therefore, I had to use the "trick" of wrapping the 16 byte array in a `struct`. While this is considered bad practice by some, I decided that it'll be fine in this case, which is anytime a standalone UUID needs to be passed over FFI. It looks like:
```rust
pub const UUID_LEN: usize = 16;

#[repr(C)]
pub struct LbFileId {
    data: [u8; UUID_LEN],
}
```

---

Closes #6.