### PR TITLE
use libc functions for string alloc and free instead of CString

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 name = "c_interface_v2"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "lockbook-core",
 ]
 

--- a/c_interface_v2/Cargo.toml
+++ b/c_interface_v2/Cargo.toml
@@ -8,3 +8,4 @@ crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
 lockbook-core = { path = "../lockbook/libs/core" }
+libc = "0.2.139"

--- a/c_interface_v2/src/account.rs
+++ b/c_interface_v2/src/account.rs
@@ -19,10 +19,10 @@ fn lb_account_new() -> LbAccount {
 #[no_mangle]
 pub unsafe extern "C" fn lb_account_free(a: LbAccount) {
     if !a.username.is_null() {
-        let _ = CString::from_raw(a.username);
+        libc::free(a.username as *mut c_void);
     }
     if !a.api_url.is_null() {
-        let _ = CString::from_raw(a.api_url);
+        libc::free(a.api_url as *mut c_void);
     }
 }
 

--- a/c_interface_v2/src/files.rs
+++ b/c_interface_v2/src/files.rs
@@ -30,7 +30,7 @@ pub struct LbFile {
     shares: LbShareList,
 }
 
-pub fn lb_file_new(f: File) -> LbFile {
+pub unsafe fn lb_file_new(f: File) -> LbFile {
     let mut typ = lb_file_type_doc();
     if let FileType::Folder = f.file_type {
         typ.tag = LbFileTypeTag::Folder;
@@ -52,10 +52,10 @@ pub fn lb_file_new(f: File) -> LbFile {
 
 pub unsafe fn lb_file_free(f: LbFile) {
     if !f.name.is_null() {
-        let _ = CString::from_raw(f.name);
+        libc::free(f.name as *mut c_void);
     }
     if !f.lastmod_by.is_null() {
-        let _ = CString::from_raw(f.lastmod_by);
+        libc::free(f.lastmod_by as *mut c_void);
     }
     lb_share_list_free(f.shares);
 }
@@ -88,7 +88,7 @@ pub struct LbShareList {
     count: usize,
 }
 
-fn lb_share_list_new(shares: Vec<Share>) -> LbShareList {
+unsafe fn lb_share_list_new(shares: Vec<Share>) -> LbShareList {
     let mut list = Vec::with_capacity(shares.len());
     for sh in shares {
         list.push(LbShare {
@@ -117,10 +117,10 @@ unsafe fn lb_share_list_free(sl: LbShareList) {
     let list = Vec::from_raw_parts(sl.list, sl.count, sl.count);
     for sh in list {
         if !sh.by.is_null() {
-            let _ = CString::from_raw(sh.by);
+            libc::free(sh.by as *mut c_void);
         }
         if !sh.with.is_null() {
-            let _ = CString::from_raw(sh.with);
+            libc::free(sh.with as *mut c_void);
         }
     }
 }
@@ -474,10 +474,10 @@ pub struct LbImexFileInfo {
 #[no_mangle]
 pub unsafe extern "C" fn lb_imex_file_info_free(fi: LbImexFileInfo) {
     if !fi.disk_path.is_null() {
-        let _ = CString::from_raw(fi.disk_path);
+        libc::free(fi.disk_path as *mut c_void);
     }
     if !fi.lb_path.is_null() {
-        let _ = CString::from_raw(fi.lb_path);
+        libc::free(fi.lb_path as *mut c_void);
     }
 }
 

--- a/c_interface_v2/src/subscription.rs
+++ b/c_interface_v2/src/subscription.rs
@@ -15,7 +15,7 @@ pub struct LbSubInfoResult {
 #[no_mangle]
 pub unsafe extern "C" fn lb_sub_info_result_free(r: LbSubInfoResult) {
     if !r.stripe_last4.is_null() {
-        let _ = CString::from_raw(r.stripe_last4);
+        libc::free(r.stripe_last4 as *mut c_void);
     }
     lb_error_free(r.err);
 }

--- a/c_interface_v2/src/sync_and_usage.rs
+++ b/c_interface_v2/src/sync_and_usage.rs
@@ -107,10 +107,10 @@ pub struct LbClientWorkUnit {
 #[no_mangle]
 pub unsafe extern "C" fn lb_sync_progress_free(sp: LbSyncProgress) {
     if !sp.current_wu.pull_doc.is_null() {
-        let _ = CString::from_raw(sp.current_wu.pull_doc);
+        libc::free(sp.current_wu.pull_doc as *mut c_void);
     }
     if !sp.current_wu.push_doc.is_null() {
-        let _ = CString::from_raw(sp.current_wu.push_doc);
+        libc::free(sp.current_wu.push_doc as *mut c_void);
     }
 }
 
@@ -197,7 +197,7 @@ pub unsafe extern "C" fn lb_usage_result_free(r: LbUsageResult) {
     let usages = Vec::from_raw_parts(r.usages, r.num_usages, r.num_usages);
     for fu in usages {
         if !fu.id.is_null() {
-            let _ = CString::from_raw(fu.id);
+            libc::free(fu.id as *mut c_void);
         }
     }
     lb_usage_item_metric_free(r.server_usage);
@@ -222,7 +222,7 @@ fn lb_usage_item_metric_none() -> LbUsageItemMetric {
 #[no_mangle]
 pub unsafe extern "C" fn lb_usage_item_metric_free(m: LbUsageItemMetric) {
     if !m.readable.is_null() {
-        let _ = CString::from_raw(m.readable);
+        libc::free(m.readable as *mut c_void);
     }
 }
 


### PR DESCRIPTION
using `CString::new` validated the rust string (by checking that none of the string's bytes were `nul`) and made a new copy of the string with an allocation. this change uses `libc` functions to allocation and free the raw memory necessary for the strings, which accomplishes two things:
1. there is one less unnecessary check being done for every string alloc (if we're passing a `nul` byte for some reason, we've done something very wrong).
2. the C developer can now use their libc functions for managing memory how they would like, instead of relying on some mechanism existing within the lockbook core C interface to do so. in other words, no longer do strings need to respect rust's memory management in order to avoid leaks.